### PR TITLE
Linked Footer In New Tab

### DIFF
--- a/_themes/sphinx_rtd_theme/footer.html
+++ b/_themes/sphinx_rtd_theme/footer.html
@@ -41,7 +41,7 @@
 
     </p>
     <p>
-        <a href="http://enhancesoft.com">Enhancesoft</a> Parent Company of <a href="http://osticket.com">osTicket</a>
+        <a href="http://enhancesoft.com" target="_blank">Enhancesoft</a> Parent Company of <a href="http://osticket.com" target="_blank">osTicket</a>
     </p>
   </div>
 


### PR DESCRIPTION
This adds a target to the footer links to open them in new tabs instead
of using the current tab.