### PR TITLE
issue: Remove RTD Links From Sidebar

### DIFF
--- a/_themes/sphinx_rtd_theme/versions.html
+++ b/_themes/sphinx_rtd_theme/versions.html
@@ -19,17 +19,8 @@
           <dd><a href="{{ url }}">{{ type }}</a></dd>
         {% endfor %}
       </dl>
-      <dl>
-        <dt>{{ _('On Read the Docs') }}</dt>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/?fromdocs={{ slug }}">{{ _('Project Home') }}</a>
-          </dd>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">{{ _('Builds') }}</a>
-          </dd>
-      </dl>
       <hr/>
-      {% trans %}Free document hosting provided by <a href="http://www.readthedocs.org">Read the Docs</a>.{% endtrans %}
+      {% trans %}Powered by <a href="http://www.readthedocs.org">Read the Docs</a>.{% endtrans %}
 
     </div>
   </div>


### PR DESCRIPTION
This removes the links back to RTD home where people can see sensitive
information from the sidebar. This also changes the RTD shoutout to
'Powered by Read the Docs'.