### PR TITLE
Fix link to cc/bcc. Wrong doc linked

### DIFF
--- a/Getting Started/v1-11 Overview.rst
+++ b/Getting Started/v1-11 Overview.rst
@@ -118,7 +118,7 @@ Additionally, collaborators can now be added upon ticket creation.
 
 Links to Documentation:
 |br|
-:doc:`Ticket Referral <../Features/Ticket Referral>`
+:doc:`Collaborators <../Features/Collaborators>`
 
 It is important to understand which email templates can be expected to go out for each scenario of this feature. The templates will determine what users will see in Alert emails that are sent out by the system. In order to see the titles of the email templates have your administrator go to:
 


### PR DESCRIPTION
The link to the new cc/bcc feature was pointing to the wrong document.