### PR TITLE
oops: SSO Guide

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -30,7 +30,6 @@ osTicket is a widely-used open source support ticket system. It seamlessly integ
    Guides/Alerts Guide
    Guides/Translation Guide
    Guides/OAuth2 Guide
-   Guides/SSO Guide
 
 
 .. toctree::


### PR DESCRIPTION
This removes the SSO Guide from the toctree until we have it ready.