### PR TITLE
update: PHP Version Wording

### DIFF
--- a/Getting Started/Installation.rst
+++ b/Getting Started/Installation.rst
@@ -6,7 +6,7 @@ osTicket comes with its own web-based installer to help guide you through the in
 Prerequisites
 -------------
 
-To install osTicket, your web server must have PHP 8.x and MySQL 5.0 (or better) installed. If you are unsure whether your server meets these requirements, please check with your host or webmaster before proceeding with the installation.
+To install osTicket, your web server must have PHP 8.0 - 8.1 (8.1 recommended) and MySQL 5.0 (or better) installed. If you are unsure whether your server meets these requirements, please check with your host or webmaster before proceeding with the installation.
 
 You will need one MySQL database with valid user, password and hostname handy during installation. MySQL user must have FULL privileges on the database. If you are unsure whether you have these details or if the user has sufficient permissions, please consult your host or database admin before proceeding.
 


### PR DESCRIPTION
This updates the PHP version in the Prerequisites section from `8.x` to `8.0 - 8.1 (8.1 recommended)` to avoid confusion with the newly released 8.2.