### PR TITLE
update: PHP Requirements 1.18.x

### DIFF
--- a/Getting Started/Installation.rst
+++ b/Getting Started/Installation.rst
@@ -6,7 +6,7 @@ osTicket comes with its own web-based installer to help guide you through the in
 Prerequisites
 -------------
 
-To install osTicket, your server must have Apache/LiteSpeed/IIS webserver (with the URL Rewrite module installed/enabled), PHP 8.0 - 8.2 (8.2 recommended), and MySQL 5.0 (or better) installed. If you are unsure whether your server meets these requirements, please check with your host or webmaster before proceeding with the installation.
+To install osTicket, your server must have Apache/LiteSpeed/IIS webserver (with the URL Rewrite module installed/enabled), PHP 8.1 - 8.2 (8.2 recommended), and MySQL 5.0 (or better) installed. If you are unsure whether your server meets these requirements, please check with your host or webmaster before proceeding with the installation.
 
 You will need one MySQL database with valid user, password and hostname handy during installation. MySQL user must have FULL privileges on the database. If you are unsure whether you have these details or if the user has sufficient permissions, please consult your host or database admin before proceeding.
 
@@ -14,7 +14,6 @@ You will need one MySQL database with valid user, password and hostname handy du
 
 #. PHP 8.2 for Windows Server `64-bit <https://windows.php.net/downloads/releases/php-8.2.6-nts-Win32-vs16-x64.zip>`__ | `32-bit <https://windows.php.net/downloads/releases/php-8.2.6-nts-Win32-vs16-x86.zip>`__
 #. PHP 8.1 for Windows Server `64-bit <https://windows.php.net/downloads/releases/php-8.1.16-nts-Win32-vs16-x64.zip>`__ | `32-bit <https://windows.php.net/downloads/releases/php-8.1.16-nts-Win32-vs16-x86.zip>`__
-#. PHP 8.0 for Windows Server `64-bit <https://windows.php.net/downloads/releases/php-8.0.28-nts-Win32-vs16-x64.zip>`__ | `32-bit <https://windows.php.net/downloads/releases/php-8.0.28-nts-Win32-vs16-x86.zip>`__
 #. MySQL 8.0 for Windows Server `64-bit <https://cdn.mysql.com/Downloads/MySQLInstaller/mysql-installer-web-community-8.0.32.0.msi>`__
 #. MariaDB 10.11 for Windows Server `64-bit <https://dlm.mariadb.com/2873464/MariaDB/mariadb-10.11.2/winx64-packages/mariadb-10.11.2-winx64.msi>`__
 #. PHP Manager 2 for IIS (makes managing PHP on IIS much easier) `here <https://www.phpmanager.xyz/>`_


### PR DESCRIPTION
This updates the Installation guide to include the PHP requirements for 1.18.x as well as removes the line for PHP 8.0 as it's no longer supported.