### PR TITLE
update: Internal Activity Recipient Wording

### DIFF
--- a/Guides/Alerts Guide.rst
+++ b/Guides/Alerts Guide.rst
@@ -60,7 +60,7 @@ New Message Alert for **Organization Manager** is sent to the Agent or Team of a
 
 Internal Activity Alert for the **Last Respondent** is sent to the last responding agent for activity on a ticket such as an internal note or another agent’s response to a ticket.
 
-Internal Activity Alert for the **Assigned Agent/Team** is sent to the assigned agent or team if there is no response from another agent posted on the ticket or the alert for last respondent is not enabled.
+Internal Activity Alert for the **Assigned Agent/Team** is sent to the assigned agent and team if there is no response from another agent posted on the ticket or the alert for last respondent is not enabled.
 
 Internal Activity Alert for the **Department Manager** is sent to the Department Manager, if set, for the Department, and the Last Respondent and Assigned Agent/Team is not listed or the alerts are not enabled.
 


### PR DESCRIPTION
This updates the wording for the Internal Activity Notice's Assigned Agent/Team recipient. It used to use the terminology "or" to say the alert is sent to an Agent -or- Team. However, the code was updated to send the alert to everyone assigned so the docs needed to be updated to reflect this. This simply changes the word "or" to "and" to be more clear about who will receive the alert.

Initial Report:
- https://github.com/osTicket/osTicket/issues/6659