### PR TITLE
update: MS OAuth2 Outlook API Deprecations 2024

### DIFF
--- a/Guides/OAuth2 Guide.rst
+++ b/Guides/OAuth2 Guide.rst
@@ -5,8 +5,6 @@
 OAuth2 Guide
 ============
 
-OAuth Authentication allows Agents/Users the ability to use Single Sign-on to log into the helpdesk through the provider you set up. The most commonly used providers are Microsoft and Google.
-
 Authentication
 --------------
 
@@ -22,6 +20,11 @@ OAuth Authentication allows Agents/Users the ability to use Single Sign-on to lo
 
 Authorization
 -------------
+
+.. attention::
+  Microsoft has started deprecating certain Outlook endpoints used in Modern Authentication (OAuth2) for Emails. Note, this does **not** affect user/agent authentication. These deprecations started causing errors similar to :code:`The API version v2 has been depreciated` when the system attempted to retrieve a new set of Tokens. This prevented new Tokens from being generated which caused authentication failures. We have now made changes to the OAuth2 plugin to support the latest Microsoft deprecations.
+
+  Please :doc:`follow the steps listed here <../OAuth2/Microsoft Authorization Guide>` to address the issue.
 
 OAuth2 Authorization allows emails the ability to authenticate against a mail server using the OAuth2 protocol. This eliminates the need to store the password locally and instead redirects you directly to the provider to login. Most provider's are phasing out Basic Authentication (username + password) for Modern Authentication (OAuth2) but if you host your own mailserver you may not have OAuth2 available. The most commonly used providers are Microsoft and Google.
 

--- a/OAuth2/Google Authentication (SSO) Guide.rst
+++ b/OAuth2/Google Authentication (SSO) Guide.rst
@@ -5,7 +5,7 @@
 Google Authentication (SSO) Guide
 =================================
 
-Google OAuth allows Agents and Users to sign into the helpdesk with their Google account.
+Google OAuth allows Agents and Users to sign into the helpdesk with their Google account. Please note, you must have the OAuth2 Plugin `installed and enabled beforehand <../Guides/OAuth2%20Guide.html#setting-up-the-plugin>`_.
 
 Configuration
 -------------

--- a/OAuth2/Google Authorization Guide.rst
+++ b/OAuth2/Google Authorization Guide.rst
@@ -1,7 +1,7 @@
 Google Authorization Guide
 ==========================
 
-This guide will walk you through how to configure Modern Authentication (OAuth2) for a Google email. Please note, you must have the OAuth2 Plugin installed and enabled beforehand.
+This guide will walk you through how to configure Modern Authentication (OAuth2) for a Google email. Please note, you must have the OAuth2 Plugin `installed and enabled beforehand <../Guides/OAuth2%20Guide.html#setting-up-the-plugin>`_.
 
 Configure Authorization
 -----------------------

--- a/OAuth2/Microsoft Authentication (SSO) Guide.rst
+++ b/OAuth2/Microsoft Authentication (SSO) Guide.rst
@@ -5,7 +5,7 @@
 Microsoft Authentication (SSO) Guide
 ====================================
 
-Microsoft OAuth allows Agents and Users to sign into the helpdesk with their Microsoft account.
+Microsoft OAuth allows Agents and Users to sign into the helpdesk with their Microsoft account. Please note, you must have the OAuth2 Plugin `installed and enabled beforehand <../Guides/OAuth2%20Guide.html#setting-up-the-plugin>`_.
 
 Configuration
 -------------

--- a/OAuth2/Microsoft Authorization Guide.rst
+++ b/OAuth2/Microsoft Authorization Guide.rst
@@ -1,7 +1,16 @@
 Microsoft Authorization Guide
 =============================
 
-This guide will walk you through how to configure Modern Authentication (OAuth2) for a Microsoft email. Please note, you must have the OAuth2 Plugin installed and enabled beforehand.
+This guide will walk you through how to configure Modern Authentication (OAuth2) for a Microsoft email. Please note, you must have the OAuth2 Plugin `installed and enabled beforehand <../Guides/OAuth2%20Guide.html#setting-up-the-plugin>`_.
+
+.. attention::
+  Microsoft has started deprecating certain Outlook endpoints used in Modern Authentication (OAuth2) for Emails. Note, this does **not** affect user/agent authentication. These deprecations started causing errors similar to :code:`The API version v2 has been depreciated` when the system attempted to retrieve a new set of Tokens. This prevented new Tokens from being generated which caused authentication failures. We have now made changes to the OAuth2 plugin to support the latest Microsoft deprecations.
+
+  To address this issue, anyone using a Microsoft email as a system email is encouraged to download and install the `latest build of the OAuth2 plugin <https://osticket.com/download>`_ specific to their version of osTicket core. Once downloaded, simply replace your existing OAuth2 PHAR file with the new one. You may want to restart the webserver (and PHP-FPM if you're running it) to clear any server-side file caching. Once complete you can follow the steps below to update your email configurations:
+
+  :doc:`Licensed/Personal Emails <../OAuth2/Microsoft Deprecations 2024/Licensed Personal Emails>`
+
+  :doc:`Shared Mailboxes/Resource Emails/Aliases <../OAuth2/Microsoft Deprecations 2024/Shared Mailboxes Resource Emails Aliases>`
 
 Configure Authorization
 -----------------------

--- a/OAuth2/Microsoft Deprecations 2024/Licensed Personal Emails.rst
+++ b/OAuth2/Microsoft Deprecations 2024/Licensed Personal Emails.rst
@@ -1,0 +1,19 @@
+Licensed/Personal Emails
+========================
+
+If you are using a real, licensed email or a personal email follow the below steps to ensure you are up-to-date with the latest Microsoft deprecations:
+
+#. Open a private browsing window. This is an important step to ensure you authorize the proper account and not your personal account, etc.
+#. Login to your osTicket helpdesk.
+#. Go to your system Emails (**Admin Panel > Emails > Emails**).
+#. Click on a system email with OAuth2 configured.
+#. Go to the **Remote Mailbox** tab.
+#. Click the **Config** button.
+#. Click the **Idp Config** tab.
+#. Completely replace the **Scopes** value with the following:
+   :code:`offline_access https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/POP.AccessAsUser.All https://outlook.office.com/SMTP.Send`
+#. Click **Submit**.
+#. A pop up will be presented for you to sign in. It's important that you sign in to the email account you are configuring in osTicket; otherwise you will authorize the wrong account.
+#. Now you should have a new token and should be able to **Save Changes** successfully.
+#. Check the **Outgoing (SMTP)** tab to see if separate OAuth2 credentials are configured (ie. if **Authentication** is set to "OAuth2 - Microsoft"). If so, repeat these steps for the SMTP tab as well.
+#. Repeat the above steps for each email you have configured in osTicket.

--- a/OAuth2/Microsoft Deprecations 2024/Shared Mailboxes Resource Emails Aliases.rst
+++ b/OAuth2/Microsoft Deprecations 2024/Shared Mailboxes Resource Emails Aliases.rst
@@ -1,0 +1,21 @@
+Shared Mailboxes/Resource Emails/Aliases
+========================================
+
+If you are using a shared mailbox, resource email, and/or alias email follow the below steps to ensure you are up-to-date with the latest Microsoft deprecations:
+
+#. Open a private browsing window. This is an important step to ensure you authorize the proper account and not your personal account, etc.
+#. Login to your osTicket helpdesk.
+#. Go to your system Emails (**Admin Panel > Emails > Emails**).
+#. Click on a system email with OAuth2 configured.
+#. Go to the **Remote Mailbox** tab.
+#. Click the **Config** button.
+#. Within the **Info** tab, disable (*uncheck*) the setting for **Strict Matching**.
+#. Click the **Idp Config** tab.
+#. Completely replace the **Scopes** value with the following:
+   :code:`offline_access https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/POP.AccessAsUser.All https://outlook.office.com/SMTP.Send`
+#. Click **Submit**.
+#. A pop up will be presented for you to sign in. It's important that you sign in to the Service Account/User Account that has **Send As** and **Read and Manage** permissions to the shared mailbox/resource email/alias.
+#. Now you should have a new token and should be able to **Save Changes** successfully.
+#. If you get an error about mismatching emails on the first submission, simply resubmit the popup and it should go through the second time.
+#. Check the **Outgoing (SMTP)** tab to see if separate OAuth2 credentials are configured (ie. if **Authentication** is set to "OAuth2 - Microsoft"). If so, repeat these steps for the SMTP tab as well.
+#. Repeat the above steps for each email you have configured in osTicket.

--- a/OAuth2/Okta Authentication (SSO) Guide.rst
+++ b/OAuth2/Okta Authentication (SSO) Guide.rst
@@ -5,7 +5,7 @@
 Okta Authentication (SSO) Guide
 ===============================
 
-Okta OAuth2 allows Agents and Users to sign into the helpdesk with their Okta account.
+Okta OAuth2 allows Agents and Users to sign into the helpdesk with their Okta account. Please note, you must have the OAuth2 Plugin `installed and enabled beforehand <../Guides/OAuth2%20Guide.html#setting-up-the-plugin>`_.
 
 Configuration
 -------------

--- a/conf.py
+++ b/conf.py
@@ -60,7 +60,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'osTicket'
-copyright = u'2022, Enhancesoft'
+copyright = u'2024, Enhancesoft'
 author = u'Enhancesoft'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
This updates the documentation to add notices about the recent MS OAuth2 Outlook endpoint deprecations. This adds information about what happened, what the resulting error was, and provides steps on how to resolve the issue. In addition this updates all OAuth2 docs to provide a notice about having the OAuth2 Plugin installed and enabled before proceeding with the setup with a link to the relevant docs. Lastly, this updates the Copyright.