### PR TITLE
rewrite engine is required for oauth2

### DIFF
--- a/Guides/OAuth2 Guide.rst
+++ b/Guides/OAuth2 Guide.rst
@@ -4,6 +4,8 @@
 
 OAuth2 Guide
 ============
+.. attention::
+  if https://localhost/api/auth/oauth2 returns error 404, makes sure you have the rewrite engine turned on in your webserver
 
 Authentication
 --------------


### PR DESCRIPTION
without the rewrite engine in apache or rewrite rules in nginx, the redirect url will return a 404